### PR TITLE
classifier::classify should be contained

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,6 +30,7 @@ class classifier (
     rules => $rules,
     debug => $debug
   }
+  contain classifier::classify
 
   $classification = $classifier::classify::classification
   $classification_classes = $classifier::classify::classification_classes


### PR DESCRIPTION
If not contained:

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: The value '' cannot be converted to Numeric. at /etc/puppetlabs/code/envir
onments/production/modules/classifier/manifests/init.pp:39:14 on node ..
```

Cheers,
M
