### PR TITLE
Adding in operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Hash[String,
     rules    => Array[
       Struct[{
         fact     => Optional[Data],
-        operator => Enum["==", "=~", ">", " =>", "<", "<=", "has_ip_network"],
+        operator => Enum["==", "=~", ">", " =>", "<", "<=", "in", "has_ip_network"],
         value    => Data,
         invert   => Optional[Boolean]
       }]
@@ -141,7 +141,7 @@ The fact is optional, since some times like in the case of `has_ip_network` for 
 not make sense since it checks a range of facts from the node.
 
 ## operator
-Valid operators are `"==", "=~", ">", " =>", "<", "<=", "has_ip_network"`, most of these comparisons
+Valid operators are `"==", "=~", ">", " =>", "<", "<=", "in", "has_ip_network"`, most of these comparisons
 are done using the `versioncmp` function so you should probably understand it to really grasp what
 these will do.
 

--- a/functions/evaluate_rule.pp
+++ b/functions/evaluate_rule.pp
@@ -32,6 +32,10 @@ function classifier::evaluate_rule (
       versioncmp($left, $right) != 1
     }
 
+    "in": {
+      $left in $right
+    }
+
     "has_ip_network": {
       classifier::has_interface_detail($right, "network")
     }

--- a/types/operators.pp
+++ b/types/operators.pp
@@ -5,5 +5,6 @@ type Classifier::Operators = Enum[
   "=>",
   "<",
   "<=",
+  "in",
   "has_ip_network"
 ]


### PR DESCRIPTION
Hi,

it would be helpful to support 'in' as an operator, especially when dealing with Arrays.

The idea is to be able to do this:
```
classifier::rules:
  "Puppetmaster role"
    rules:
      - fact: "%{::roles}"
         operator: "in"
         value: "puppetmaster"
    classes:
      - "puppet::server"
```

Solves #4 

Thanks :)