### PR TITLE
has_ip_network: fixes for undef parameter

### DIFF
--- a/functions/has_interface_detail.pp
+++ b/functions/has_interface_detail.pp
@@ -27,8 +27,10 @@ function classifier::has_interface_detail (
       $interface["mac"]
     } else {
       ["bindings", "bindings6"].map |$bname| {
-        $interface[$bname].map |$binding| {
-          $binding[$what]
+        if $bname in $interface {
+          $interface[$bname].map |$binding| {
+            $binding[$what]
+          }
         }
       }
     }


### PR DESCRIPTION
  check $bname variable before binding. This fixes some cases with
parameter "enumerable" expects an Iterable value, Issue #22